### PR TITLE
Testing detector on both video and image files with a single interface

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,22 +1,50 @@
 #include <iostream>
+#include <memory>
 #include <opencv2/opencv.hpp>
+#include <opencv2/video/video.hpp>
+
 #include "fpdw_detector.h"
 
+#include <media.hpp>
 
 int main(int argc, char **argv)
 {
-    cv::Mat image = cv::imread(argv[2]);
-    fpdw::detector::FPDWDetector detector(argv[1], 0.);
-    
-    detector.process(image);
-    std::vector<cv::Rect> rect = detector.getBBoxes();
-
-    for(const auto &i : rect)
+    if(argc != 3)
     {
-        cv::rectangle(image, i, cv::Scalar(255, 0, 0), 2);
+        std::cout << "Usage:\n";
+        std::cout << "./fpdw /path/to/detector/xml /path/to/image/or/video/file\n";
+        return EXIT_FAILURE;
     }
-    
-    cv::imshow("image", image);
-    cv::waitKey(0);
+
+    media::MediaWrapper::Ptr media;
+    try{
+        media = media::MediaFactory::Create(argv[2]);
+    }
+    catch (std::runtime_error e)
+    {
+        std::cout << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    fpdw::detector::FPDWDetector detector(argv[1], 0.0);
+
+    cv::Mat image;
+    bool nextImageAvailable = true;
+    while(nextImageAvailable)
+    {
+        nextImageAvailable = media->getImage(image);
+
+        detector.process(image);
+        std::vector<cv::Rect> rect = detector.getBBoxes();
+
+        for(const auto &i : rect)
+        {
+            cv::rectangle(image, i, cv::Scalar(255, 0, 0), 2);
+        }
+
+        cv::imshow("image", image);
+        media->waitKey();
+    }
+
     return 0;
 }

--- a/src/media.hpp
+++ b/src/media.hpp
@@ -1,0 +1,125 @@
+//
+// Created by yildirim on 02.09.16.
+//
+
+#ifndef FPDW_MEDIA_H
+#define FPDW_MEDIA_H
+
+#include <fstream>
+#include <stdexcept>
+
+namespace media {
+
+    class ExtensionFactory
+    {
+    public:
+        static std::vector<std::string> GetImageExtensions()
+        {
+            std::vector<std::string> extensions{ "jpg", "bmp", "jpeg", "tiff", "png", "tif" };
+            return extensions;
+        }
+    };
+
+    bool isAmongSetOfStrings(const char *extension, std::vector<std::string> str_array) {
+        return std::find(str_array.begin(), str_array.end(), extension) != str_array.end();
+    }
+
+    bool file_exists(const std::string& name)
+    {
+        std::ifstream f(name.c_str());
+        if (f.good()) {
+            f.close();
+            return true;
+        } else {
+            f.close();
+            return false;
+        }
+    }
+
+    bool isImageFile(const char *filename) {
+        std::string str_filename(filename);
+        size_t index = str_filename.find_last_of(".");
+
+        if (index == std::string::npos) {
+            return false;
+        }
+
+        std::string ext = str_filename.substr(index + 1, 4);
+        std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+
+        if (!isAmongSetOfStrings(ext.c_str(), ExtensionFactory::GetImageExtensions()))
+            return false;
+
+        return true;
+    }
+
+    class MediaWrapper {
+    public:
+        virtual bool getImage(cv::Mat& image) = 0;
+        virtual bool waitKey() = 0;
+
+    public:
+        typedef std::shared_ptr<MediaWrapper> Ptr;
+    };
+
+    class VideoMedia : public MediaWrapper {
+    public:
+        VideoMedia(const char *filename) {
+            if(!cap.open(filename))
+                throw std::runtime_error("Cannot start video stream!");
+        }
+
+        bool getImage(cv::Mat& image) {
+            cap >> image;
+            return !image.empty();
+        }
+
+        bool waitKey()
+        {
+            cv::waitKey(20);
+        }
+
+    private:
+        cv::VideoCapture cap;
+
+    public:
+        typedef std::shared_ptr<VideoMedia> Ptr;
+    };
+
+    class ImageMedia : public MediaWrapper {
+    public:
+        ImageMedia(const char *filename) : filename(filename){
+            if(!file_exists(filename))
+                throw std::runtime_error("Image file does not exist");
+        }
+
+        bool getImage(cv::Mat& image) {
+            image = cv::imread(filename);
+            return false;
+        }
+
+        bool waitKey()
+        {
+            cv::waitKey(0);
+        }
+
+    private:
+        const char* filename;
+
+    public:
+        typedef std::shared_ptr<ImageMedia> Ptr;
+    };
+
+    class MediaFactory {
+    public:
+        static MediaWrapper::Ptr Create(const char *filename) {
+            bool isImage = isImageFile(filename);
+            if (isImage)
+                return std::make_shared<ImageMedia>(filename);
+            else
+                return std::make_shared<VideoMedia>(filename);
+        }
+    };
+}
+
+#endif //FPDW_MEDIA_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -36,6 +36,7 @@
 #include <vector>
 #include <opencv2/opencv.hpp>
 #include <omp.h>
+#include <typeinfo>
 
 #include "sse.hpp"
 #include "structs.h"
@@ -44,6 +45,7 @@
 namespace fpdw
 {
     namespace utils
+    {
     {
         class Convolution
         {

--- a/src/utils.h
+++ b/src/utils.h
@@ -46,7 +46,6 @@ namespace fpdw
 {
     namespace utils
     {
-    {
         class Convolution
         {
             public:


### PR DESCRIPTION
Hi, 

Application displays a message indicating the correct usage when incorrect numbers of parameters are provided. 
Detector is now able to run on both image and video files. For this purpose I added a header file, media.hpp, acting as an interface for image sources. 

namespace media contains useful helper functions as well. 

Best.
